### PR TITLE
Add "insufficient" as alias for grade 5 in tiss-ects-chart

### DIFF
--- a/tiss-ects-chart.user.js
+++ b/tiss-ects-chart.user.js
@@ -5,7 +5,7 @@
 // @require     https://cdn.jsdelivr.net/npm/chart.js@2.8.0
 // @description add charts to TISS certificates
 // @include     https://tiss.tuwien.ac.at/graduation/certificates.xhtml*
-// @version     1.2
+// @version     1.3
 // @downloadURL https://fsinf.at/userscripts/tiss-ects-chart.user.js
 // @updateURL   https://fsinf.at/userscripts/tiss-ects-chart.user.js
 // ==/UserScript==

--- a/tiss-ects-chart.user.js
+++ b/tiss-ects-chart.user.js
@@ -27,6 +27,7 @@ function mapGrade(grade) {
     switch(grade) {
         case "nicht genügend":
         case "unsatisfactory":
+        case "insufficient":
             ans = 5;
             break;
         case "genügend":


### PR DESCRIPTION
The charts didn't recognize my "Nicht Genügend" because they are denoted as "insufficient" instead of "unsatisfactory" and while that made me feel warm and fuzzy inside I'm not quite ready to reject reality just yet.