### PR TITLE
fix broken ects chart table selector

### DIFF
--- a/tiss-ects-chart.user.js
+++ b/tiss-ects-chart.user.js
@@ -10,7 +10,7 @@
 // @updateURL   https://fsinf.at/userscripts/tiss-ects-chart.user.js
 // ==/UserScript==
 
-var table = document.querySelector("#certificateList\\:j_id_3p > div > table")
+var table = document.querySelector("form #certificateList\\:certificatesPanel table")
 
 function findTerm(date) {
     let splitted = date.split('.');


### PR DESCRIPTION
Right now the ECTS chart script is broken, because `#certificateList:j_id_3p` was changed to `#certificateList:j_id_3q`.

This patch uses a different selector that does not use any "generated" ids (in hopes that changes to TISS won't break it again).